### PR TITLE
Added a workaround for timezone info serialization bug in netcore

### DIFF
--- a/NEsper/NEsper/client/ConfigurationEngineDefaults.cs
+++ b/NEsper/NEsper/client/ConfigurationEngineDefaults.cs
@@ -860,7 +860,7 @@ namespace com.espertech.esper.client
             /// https://github.com/dotnet/corefx/issues/40578
             /// https://stackoverflow.com/a/57662000/706456
             /// </summary>
-            /// <value>time zone</value>
+            /// <value>time zone id</value>
             public string TimeZoneId { get; set; }
 
             /// <summary>

--- a/NEsper/NEsper/client/ConfigurationEngineDefaults.cs
+++ b/NEsper/NEsper/client/ConfigurationEngineDefaults.cs
@@ -855,10 +855,22 @@ namespace com.espertech.esper.client
             public MathContext MathContext { get; set; }
 
             /// <summary>
+            /// Returns the time zone id for calendar operations.
+            /// Used as a workaround for .net core serialization issue
+            /// https://github.com/dotnet/corefx/issues/40578
+            /// https://stackoverflow.com/a/57662000/706456
+            /// </summary>
+            /// <value>time zone</value>
+            public string TimeZoneId { get; set; }
+
+            /// <summary>
             /// Returns the time zone for calendar operations.
             /// </summary>
             /// <value>time zone</value>
-            public TimeZoneInfo TimeZone { get; set; }
+            public TimeZoneInfo TimeZone {
+                get => TimeZoneInfo.FindSystemTimeZoneById(TimeZoneId);
+                set => TimeZoneId = value.Id;
+            }
         }
 
         /// <summary>Holds engine execution-related settings.</summary>


### PR DESCRIPTION
This PR adds a workaround for .net core serialization issue on Linux platforms.

.net issue: https://github.com/dotnet/corefx/issues/40578
suggested workaround: https://stackoverflow.com/a/57662000/706456

This repo doesn't have bors merge bot

